### PR TITLE
some small helps

### DIFF
--- a/shadchen.el
+++ b/shadchen.el
@@ -1,4 +1,4 @@
-;;; shadchen.el --- pattern matching for elisp -*- lexical-binding: t -*-
+;;; shadchen.el --- pattern matching for elisp
 
 ;; Version: 1.0
 ;; Author: Vincent Toups

--- a/shadchen.el
+++ b/shadchen.el
@@ -1516,12 +1516,9 @@ TYPE is either `:alist' or `:plist'."
                `(funcall (shadchen/extract ,k :plist) ,v))))
 
 (defpattern alist (&rest kv-pairs)
-  (cl-labels ((alist-get (key)
-                         (lambda (alist)
-                           (cdr (assoc key alist)))))
-    `(and ,@(loop for (k v . rest) on kv-pairs by #'cddr
-               collect
-                 `(funcall (shadchen/extract ,k :alist) ,v)))))
+  `(and ,@(loop for (k v . rest) on kv-pairs by #'cddr
+             collect
+               `(funcall (shadchen/extract ,k :alist) ,v))))
 
 
 (provide 'shadchen)

--- a/shadchen.el
+++ b/shadchen.el
@@ -769,6 +769,7 @@ FORMS.  When a match is detected, its subsequent forms are executed as
 in a PROGN where the bindings implied by the match are in effect.  
 
 An error is thrown when no matches are found."
+        (declare (debug (form &rest sexp)))
 	(let ((name (gensym "MATCH-VALUE-NAME-"))
 		  (current-match-form `(match ,value ,@forms)))
 	  `(let ((,name ,value)) 
@@ -782,8 +783,9 @@ in a PROGN where the bindings implied by the match are in effect.
 An error is thrown when no matches are found.  Bindings are
 lexical via cl.el's lexical let.  An alternative is to use Emacs
 24's lexical binding mode and use regular match."
+        (declare (debug (form &rest sexp)))
 	(let ((*shadchen-binding-mode* :lexical))
-	  (macroexpand-all `(match value ,@forms))))
+	  (macroexpand-all `(match ,value ,@forms))))
 
   (defmacro* match-lambda (&body forms) 
 	"Like MATCH except the VALUE is curried."

--- a/tests.el
+++ b/tests.el
@@ -1,56 +1,67 @@
-(byte-compile-file "./shadchen.el" t)
+;;; tests.el --- tests for shadchen.el
 
-;; symbol
-(assert 
- (equal 
-  10
-  (match 10
-		 (x x)))
- ()
- "symbol match failed.")
+(require 'shadchen)
+(require 'ert)
 
-;; string
-(assert
- (equal "test"
-		(match "test"
-			   ("test" "test"))))
 
-;; string-fail
-(assert 
- (equal :fail
-		(match "test"
-			   ("dog" :pass)
-			   (_ :fail))))
+(ert-deftest shadchen-symbol-match-failed ()
+  "Test symbol matching."
+  (assert 
+   (equal 
+    10
+    (match 10
+           (x x)))
+   ()
+   "symbol match failed."))
 
-;; list
-(assert 
- (equal 
-  (list 1 2 3)
-  (match (list 1 2 3)
-		 ((list x y z)
-		  (list x y z)))))
+(ert-deftest shadchen-match-string ()
+  "Match a string."
+  (should
+   (equal "test"
+          (match "test"
+                 ("test" "test")))))
+
+(ert-deftest shadchen-match-string-failed ()
+  "Match a string fails."
+  (assert 
+   (equal :fail
+          (match "test"
+                 ("dog" :pass)
+                 (_ :fail)))))
+
+(ert-deftest shadchen-match-list ()
+  "Matching a list."
+  (assert 
+   (equal 
+    (list 1 2 3)
+    (match (list 1 2 3)
+           ((list x y z)
+            (list x y z))))))
 
 
 ;; lexical
 
-;; lexical-match symbol
+(ert-deftest shadchen-match-lexically ()
+  "lexical-match symbol"
+  (should
+   (equal 10
+          (let 
+              ((f 
+                (lexical-match 10 
+                               (x 
+                                (lambda ()
+                                  x)))))
+            (funcall f)))))
 
-(assert 
- (equal 10
-		(let 
-			((f 
-			  (lexical-match 10 
-							 (x 
-							  (lambda ()
-								x)))))
-		  (funcall f))))
 
 (defun-match- test-product (nil acc)
   "Return the accumulator."
   acc)
+
 (defun-match test-product ((list-rest hd tl) acc)
   "Recur, mult. the acc by the hd."
   (recur tl (* hd acc)))
+
 (defun-match test-product (lst)
   "Entry-point: find the product of the numbers in LST."
   (recur lst 1))
@@ -65,18 +76,23 @@
 
 ;; Alists and Plists
 
-(assert
- (equal
-  (match
-   '(:one 1 :two 2 :three 3)
-   ((plist :two a) a))
-  2)) ; because that's the value of :two in the plist
+(ert-deftest shadchen-match-plist ()
+  "Show plist matching working."
+  (assert
+   (equal
+    (match
+     '(:one 1 :two 2 :three 3)
+     ((plist :two a) a))
+    2))) ; because that's the value of :two in the plist
 
-(assert
- (equal
-  (match
-   '((a . 1)(b . 2)(c . 3))
-   ((alist 'c a) a))
-  3)) ; because that's the value of 'c in the alist
+(ert-deftest shadchen-match-alist ()
+  "Show alist matching working."
+  (assert
+   (equal
+    (match
+     '((a . 1)(b . 2)(c . 3))
+     ((alist 'c a) a))
+    3))) ; because that's the value of 'c in the alist
 
-;; 
+
+;;; tests.el ends here


### PR DESCRIPTION
I removed a spurious cl-labels in my alist impl.

And I ert'd the tests although I don't understand what you're trying to do with the test-product stuff.

The other suggestion I'd like to make is that you pull all the shadchen stuff into the top-level and drop the use of `eval-when` because then emacs can find the source properly and all of that.

I also fixed a bug in lexical-match and I added stuff to make it possible to step into the match (and lexical-match) macro, at least for the value. We'd have to find a way to express the destructured match/expression to be able to step into those... might be tricky.

Oh. I also noticed that the version wasn't bumped in the file. I haven't updated that. Do you have a commit somewhere for that?
