### PR TITLE
A bunch of fixes for a 1.4

### DIFF
--- a/shadchen.el
+++ b/shadchen.el
@@ -787,7 +787,7 @@ FORMS.  When a match is detected, its subsequent forms are executed as
 in a PROGN where the bindings implied by the match are in effect.  
 
 An error is thrown when no matches are found."
-  (declare (debug (form &rest sexp)))
+  (declare (debug (form &rest sexp))(indent 1))
   (let ((name (gensym "MATCH-VALUE-NAME-"))
         (current-match-form `(match ,value ,@forms)))
     `(let ((,name ,value)) 

--- a/shadchen.el
+++ b/shadchen.el
@@ -923,6 +923,7 @@ match, but only in tail position.
 
 At the moment, this is not checked at compile time, so unexpected
 results can occur if `recur` is used in another position.s"
+  (declare (debug (sexp &rest form))(indent 1))
   (let ((patterns (mapcar #'car binders))
         (recursion-sigil (gensym "recursion-sigil-"))
         (recur-args (gensym "recur-args-"))
@@ -948,6 +949,7 @@ results can occur if `recur` is used in another position.s"
 
 (defmacro* match-let* (binders &body body)
   "Like let* except patterns may appear at any location a binding symbol appears."
+  (declare (indent 1))
   (cond ((null binders)
          `(progn ,@body))
         (t
@@ -972,6 +974,7 @@ results can occur if `recur` is used in another position.
 
 Bindings are lexical via cl.el's lexical-let.  An alternative is
 to use Emacs 24 & >'s lexical binding mode with regular match-let."
+  (declare (indent 1))
   (let ((patterns (mapcar #'car binders))
         (recursion-sigil (gensym "recursion-sigil-"))
         (recur-args (gensym "recur-args-"))

--- a/shadchen.el
+++ b/shadchen.el
@@ -100,9 +100,13 @@
 ;; Matches <P1> - <PN> to elements in at list, as in the `LIST` pattern.
 ;; The final `<REST-PATTERN>` is matched against the rest of the list.
 ;;
+;;     (LIST* <P1> ... <PN> <REST-PATTERN>)
+;;
+;; LIST* is an alias for LIST-REST.
+;;
 ;;     (PLIST key <pattern> ...)
 ;; 
-;;     Matches a plist by matching each <pattern> against the key it is paired with.
+;; Matches a plist by matching each <pattern> against the key it is paired with.
 ;;
 ;;     (ALIST key <pattern> ...)
 ;; 

--- a/shadchen.el
+++ b/shadchen.el
@@ -110,7 +110,7 @@
 ;;
 ;;     (ALIST key <pattern> ...)
 ;; 
-;;     Matches an alist by matching each <pattern> against the key it is paired with.
+;; Matches an alist by matching each <pattern> against the key it is paired with.
 ;;
 ;;     (QUOTE DATUM)
 ;;

--- a/shadchen.el
+++ b/shadchen.el
@@ -1526,7 +1526,7 @@ the matching expression from the body."
 
 TYPE is either `:alist' or `:plist'."
   (lexical-let ((typ type)
-                (k (intern key)))
+                (k key))
     (lambda (kvlist)
       (case typ
         (:struct (apply (symbol-function k) (list kvlist)))

--- a/shadchen.el
+++ b/shadchen.el
@@ -95,7 +95,7 @@
 ;; Matches a list of length N, then matches each pattern `<PN>` to the
 ;; elements of that list.
 ;;
-;;     (LIST-REST <P1> ... <PN> <REST-PATTERN)
+;;     (LIST-REST <P1> ... <PN> <REST-PATTERN>)
 ;;
 ;; Matches <P1> - <PN> to elements in at list, as in the `LIST` pattern.
 ;; The final `<REST-PATTERN>` is matched against the rest of the list.

--- a/shadchen.el
+++ b/shadchen.el
@@ -1,6 +1,6 @@
 ;;; shadchen.el --- pattern matching for elisp
 
-;; Version: 1.3
+;; Version: 1.4
 ;; Author: Vincent Toups
 ;; Maintainer: Vincent Toups
 ;; Tags: pattern matching, functional programming

--- a/tests.el
+++ b/tests.el
@@ -94,5 +94,14 @@
      ((alist 'c a) a))
     3))) ; because that's the value of 'c in the alist
 
+(ert-deftest shadchen-funcall-find-if-example ()
+  "A good example of using `find-if' with funcall."
+  ;; We want to match only the first string element from the list...
+  (should
+   (equal
+    (match
+     `(1 2 sym "a string" 2 3 4)
+     ((funcall (lambda (l) (find-if 'stringp l)) a) a))
+    "a string")))
 
 ;;; tests.el ends here

--- a/tests.el
+++ b/tests.el
@@ -94,6 +94,25 @@
      ((alist 'c a) a))
     3))) ; because that's the value of 'c in the alist
 
+(ert-deftest shadchen-match-struct ()
+  ;; First define a struct
+  (defstruct shadchen-testpat name version address)
+  ;; Now let's test a struct object match with shadchen
+  (equal 
+   (let ((struct-obj (make-shadchen-testpat
+                      :name "test1"
+                      :version "0.0.1"
+                      :address "test1.example.com")))
+     (match struct-obj
+       ((struct shadchen-testpat
+                name name
+                version v) (list name v))))
+   (list "test1" "0.0.1")))
+
+
+
+;;; Example tests
+
 (ert-deftest shadchen-funcall-find-if-example ()
   "A good example of using `find-if' with funcall."
   ;; We want to match only the first string element from the list...

--- a/tests.el
+++ b/tests.el
@@ -80,8 +80,7 @@
   "Show plist matching working."
   (assert
    (equal
-    (match
-     '(:one 1 :two 2 :three 3)
+    (match '(:one 1 :two 2 :three 3)
      ((plist :two a) a))
     2))) ; because that's the value of :two in the plist
 
@@ -89,9 +88,8 @@
   "Show alist matching working."
   (assert
    (equal
-    (match
-     '((a . 1)(b . 2)(c . 3))
-     ((alist 'c a) a))
+    (match '((a . 1)(b . 2)(c . 3))
+      ((alist 'c a) a))
     3))) ; because that's the value of 'c in the alist
 
 (ert-deftest shadchen-match-struct ()


### PR DESCRIPTION
- some doc fixes,
- some test stuff
- a fix for alists to allow keys to be symbols or strings
- indentation for the match forms
- a struct pattern matcher along the lines of the alist and plist
